### PR TITLE
multiple galleries in different content/ subfolders

### DIFF
--- a/layouts/gallery/list.html
+++ b/layouts/gallery/list.html
@@ -6,7 +6,7 @@
 {{ if .Site.Params.clickablePhotos }}
     <div class="grid">
         {{ $name := .Site.Params.galleryFolder | default "images/"}}
-        {{ $path := "gallery/" }}
+        {{ $path := .File.Dir }}
         {{ $content := "/content/" }}
         {{ $src := (print $path $name) }}
 


### PR DESCRIPTION
replace the hardcoded `gallery/` subdirectory by the directory of `_index.md`.